### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Grigorii Moskalev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ Checks: `npm run build`, `npx vitest run`, and `cargo test` inside `src-tauri`. 
 The released macOS build comes from CI (`.github/workflows/macos.yml`, on a `v*` tag or by hand): the same three checks on `macos-latest`, then a universal `.dmg` attached to the release.
 
 Stack: Tauri 2, React, CodeMirror 6, unified (remark and rehype), Shiki, KaTeX, Mermaid. Rust handles the file system, folder watching, and search.
+
+## License
+
+[MIT](LICENSE). Project page: [gmoskalev.com/plain](https://gmoskalev.com/plain).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "plain",
   "private": true,
   "version": "0.2.1",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plain"
 version = "0.2.1"
 description = "Plain — a monospace markdown reader/editor"
+license = "MIT"
 edition = "2021"
 rust-version = "1.85"
 


### PR DESCRIPTION
## Summary

- `LICENSE` with the MIT text.
- `license` field in `package.json` and `Cargo.toml`.
- License section in the README with a link to the project page at gmoskalev.com/plain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XTaUQm3mUvAPRto1hLgVs

---
_Generated by [Claude Code](https://claude.ai/code/session_014XTaUQm3mUvAPRto1hLgVs)_