### PR TITLE
macOS: the window that could not be brought back (0.2.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Builds for both systems are on the [releases page](https://github.com/gregmos/pl
 
 ### Windows 11
 
-1. Unpack `Plain-0.2.1-win-x64.zip` into any folder, for example `C:\Program Files\Plain` or `%LOCALAPPDATA%\Programs\Plain`. It contains a single `plain.exe`; there is no installer.
+1. Unpack `Plain-0.2.2-win-x64.zip` into any folder, for example `C:\Program Files\Plain` or `%LOCALAPPDATA%\Programs\Plain`. It contains a single `plain.exe`; there is no installer.
 2. Run `plain.exe`.
 3. To open `.md` files in Plain with a double-click: right-click any `.md` file → **Open with → Choose another app → Plain → Always**. Plain appears in that list after its first launch, but it never makes itself the default on its own.
 
@@ -31,7 +31,7 @@ If you move the folder later, just run the exe from its new location.
 
 ### macOS 13+
 
-1. Download `Plain_0.2.1_universal.dmg`, open it, and drag Plain into Applications. One build runs on both Apple Silicon and Intel.
+1. Download `Plain_0.2.2_universal.dmg`, open it, and drag Plain into Applications. One build runs on both Apple Silicon and Intel.
 2. To open `.md` files from Finder with a double-click: select any `.md` file, **Get Info → Open with → Plain → Change All**. Plain is listed there from its first launch.
 
 ## Using it
@@ -75,7 +75,7 @@ On Windows you need Node.js 22, Rust (`rustup` with the `stable-x86_64-pc-window
 ```
 npm install
 npm run tauri dev     # development build with live reload
-npm run pack          # release build, produces dist-win\Plain-0.2.1-win-x64.zip
+npm run pack          # release build, produces dist-win\Plain-0.2.2-win-x64.zip
 ```
 
 Checks: `npm run build`, `npx vitest run`, and `cargo test` inside `src-tauri`. The manual checklist used before a release is in `CHECKLIST.md`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plain",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plain",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plain",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2915,7 +2915,7 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "blake3",
  "chardetng",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plain"
-version = "0.2.1"
+version = "0.2.2"
 description = "Plain — a monospace markdown reader/editor"
 license = "MIT"
 edition = "2021"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -257,6 +257,17 @@ fn allow_asset_dir(app: tauri::AppHandle, path: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Brings the one window back in front of the user: out of the Dock or the
+/// taskbar if it was minimised, and focused. What a second launch, a click on
+/// the Dock icon and a double-clicked file all end with.
+fn surface<R: Runtime>(app: &tauri::AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
 /// The webview never leaves our own origin (spec §14); links open in the
 /// system browser instead.
 fn navigation_guard<R: Runtime>() -> TauriPlugin<R> {
@@ -277,11 +288,7 @@ pub fn run() {
         // Order matters: single-instance first (spec §13), and persisted-scope
         // reads the fs scope during its own setup, so fs has to come before it.
         .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.unminimize();
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
+            surface(app);
             let cwd = Path::new(&cwd);
             let paths = path_args(argv.clone(), cwd);
             let folders = folder_args(argv, cwd);
@@ -386,11 +393,20 @@ pub fn run() {
                     let _ = _app.emit(QUIT_REQUESTED, ());
                 }
             }
+            // A click on the Dock icon. AppKit is told not to do its own
+            // reopen handling (tao answers with `has_visible_windows`), so a
+            // minimised window would stay in the Dock unless we bring it back.
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = &_event {
+                surface(_app);
+            }
             // Finder does not pass a path in argv: it sends the app an Apple
             // Event, which Tauri turns into this (spec §13a). Same queue the
-            // command line uses, same nudge to the front end.
+            // command line uses, same nudge to the front end — and the window
+            // comes forward, out of the Dock if it was minimised there.
             #[cfg(target_os = "macos")]
             if let tauri::RunEvent::Opened { urls } = _event {
+                surface(_app);
                 let paths: Vec<String> = urls
                     .iter()
                     .filter_map(|url| url.to_file_path().ok())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -372,11 +372,16 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building Plain")
         .run(|_app, _event| {
-            // The Dock's Quit, and anything else that asks the app to go:
-            // held back and handed to the same scenario as `⌘Q` (review #1).
+            // Anything that asks the app to go without a code — held back and
+            // handed to the same scenario as `⌘Q` (review #1). But only while
+            // there is a window to answer: the same event comes when the last
+            // window is destroyed, which is how the window's X ends after its
+            // own question. Preventing the exit then left the process alive
+            // with no window, nobody to receive the event, and no way to get
+            // a window back from the Dock or from a double-clicked file.
             #[cfg(target_os = "macos")]
             if let tauri::RunEvent::ExitRequested { api, code, .. } = &_event {
-                if code.is_none() {
+                if code.is_none() && _app.get_webview_window("main").is_some() {
                     api.prevent_exit();
                     let _ = _app.emit(QUIT_REQUESTED, ());
                 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Plain",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "Plain",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Fixes the report from a macOS user: the Plain window disappears and cannot be brought back into view.

**Cause 1: closing the window left a process with no window.** The window's X (and `file → exit`) ends in `window.destroy()` after the unsaved-changes question. With the last window gone, Tauri sends `ExitRequested { code: None }`, the same event the macOS handler treated as the Dock's Quit: it prevented the exit and emitted `plain:quit-requested` into a webview that no longer existed. The process stayed in the Dock with no window; a Dock click, a double-clicked `.md` and a second launch all went to nobody. Now the exit is held back only while the main window still exists to answer.

**Cause 2: a minimised window stayed minimised.** tao answers `applicationShouldHandleReopen` with `hasVisibleWindows`, so with the only window minimised AppKit is told to do nothing on a Dock click, and Plain had no `Reopen` handler. Same for a file opened from Finder into a minimised window. Both now go through the same unminimise / show / focus helper the second-launch callback already used.

Version bumped to 0.2.2.

Verified here: `cargo check`, `cargo test` (87 tests) on Linux. The macOS-only branch is compiled by the macOS workflow; to check by hand: close the window with X (Plain leaves the Dock), minimise and click the Dock icon (window comes back), minimise and open a file from Finder (window comes back with the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMBW3jduj3fWxXUSip9DUc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMBW3jduj3fWxXUSip9DUc)_